### PR TITLE
Fix example clang++ compile command

### DIFF
--- a/user-guide/modules/ROOT/pages/getting-started.adoc
+++ b/user-guide/modules/ROOT/pages/getting-started.adoc
@@ -845,7 +845,7 @@ Clang:
 
 [source,none,subs="attributes+"]
 ----
-clang++ -I /usr/local/include example.cpp -L /usr/local/libboost_json.a -o example
+clang++ -I /usr/local/include example.cpp -L /usr/local/lib -l boost_json -o example
 ----
 
 NOTE: Replace `C:\boost` or `/usr/local` with your Boost installation prefix if necessary.


### PR DESCRIPTION
The example command for compiling the compiled JSON library example using clang++ incorrectly uses the link path option to provide a full path to the boost_json library. That option needs to have only the path to the directory containing that library, and then the `-l` flag needs to also be passed, with the name of the library.