### PR TITLE
Update current boost version to 1.89.0

### DIFF
--- a/user-guide/modules/ROOT/pages/getting-started.adoc
+++ b/user-guide/modules/ROOT/pages/getting-started.adoc
@@ -8,8 +8,8 @@ Official repository: https://github.com/boostorg/website-v2-docs
 ////
 = Getting Started
 :navtitle: Getting Started
-:latest_tag: 1_85_0
-:latest_version: 1.85.0
+:latest_tag: 1_89_0
+:latest_version: 1.89.0
 :release_basename: boost_{latest_tag}
 :release_filename: {release_basename}.tar.bz2
 :release_zip_filename: {release_basename}.zip


### PR DESCRIPTION
The current [webpage](https://www.boost.org/doc/user-guide/getting-started.html) refers to boost [1.85.0](https://www.boost.org/releases/1.85.0/) 

The current boost release is [1.89.0](https://www.boost.org/releases/1.89.0/).

<img width="2279" height="855" alt="Screenshot_20250904_135339" src="https://github.com/user-attachments/assets/b6c65179-1408-4042-af90-32d158d6f7bf" />
