### PR TITLE
fix(nav): prevent multiple active items in menu

### DIFF
--- a/antora-ui/src/js/01-nav.js
+++ b/antora-ui/src/js/01-nav.js
@@ -89,7 +89,7 @@
       return
     }
     if (navItem === currentPageItem) return
-    find(menuPanel, '.nav-item.is-active').forEach(function (el) {
+    find(menuPanel, '.is-active, .is-current-path, .is-current-page').forEach(function (el) {
       el.classList.remove('is-active', 'is-current-path', 'is-current-page')
     })
     navItem.classList.add('is-current-page')
@@ -107,7 +107,7 @@
     var ancestorClasses
     var ancestor = navItem.parentNode
     while (!(ancestorClasses = ancestor.classList).contains('nav-menu')) {
-      if (ancestor.tagName === 'LI' && ancestorClasses.contains('nav-item')) {
+      if (ancestor.tagName === 'LI') {
         ancestorClasses.add('is-active', 'is-current-path')
       }
       ancestor = ancestor.parentNode


### PR DESCRIPTION
- **Bug:** multiple sub nav-list items stay active when clicking through, the code only clears `.nav-item.is-active` but markup lacks `.nav-item`.
- **Fix:** clear `is-active/is-current-path/is-current-page` globally, then set current and ancestors; corrects the hash nav