### PR TITLE
Correcting CMake Version to include min and max

### DIFF
--- a/user-guide/modules/ROOT/pages/getting-started.adoc
+++ b/user-guide/modules/ROOT/pages/getting-started.adoc
@@ -609,7 +609,7 @@ Here's an example `CMakeLists.txt` file that uses Boost:
 [source,cmake]
 .CMakeLists.txt
 ----
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8...3.31)
 project(MyProject)
 
 find_package(Boost REQUIRED)
@@ -779,7 +779,7 @@ Edit the contents of `CMakeLists.txt`:
 [source,cmake]
 .CMakeLists.txt
 ----
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8...3.31)
 project(MyProject)
 
 find_package(Boost REQUIRED COMPONENTS json)


### PR DESCRIPTION
cmake_minimum_required(VERSION 3.8...3.31)

I am not a CMake user and on first viewing this looks like the maximum version is lower than the minimum. ChatGPT informs me this should be read as 3 version eight and 3 version thirty-one. I hope this nuance is well known among CMake users, otherwise perhaps a note to this effect should be added too.
