### PR TITLE
feat: enhance c++ syntax highlighting with attribute support

### DIFF
--- a/antora-ui/src/css/cpp-highlight.css
+++ b/antora-ui/src/css/cpp-highlight.css
@@ -3,11 +3,10 @@
  * This replaces highlight.js's C++ highlighting for consistent styling
  */
 
-/* C++ Keywords - blue, bold */
+/* C++ Keywords - blue */
 code.cpp-highlight .cpp-keyword,
 .doc pre.highlight code.cpp-highlight .cpp-keyword {
   color: #00f;
-  font-weight: bold;
 }
 
 /* C++ Strings - dark red */
@@ -27,6 +26,12 @@ code.cpp-highlight .cpp-comment,
 .doc pre.highlight code.cpp-highlight .cpp-comment {
   color: #008000;
   font-style: italic;
+}
+
+/* C++ Attributes - gray */
+code.cpp-highlight .cpp-attribute,
+.doc pre.highlight code.cpp-highlight .cpp-attribute {
+  color: #9e9e9e;
 }
 
 /* Base text in C++ blocks - plain black (identifiers, function names, etc.) */

--- a/antora-ui/src/js/vendor/cpp-highlight.js
+++ b/antora-ui/src/js/vendor/cpp-highlight.js
@@ -6,6 +6,7 @@
  *   - string      : String and character literals
  *   - preprocessor: Preprocessor directives (#include, #define, etc.)
  *   - comment     : C and C++ style comments
+ *   - attribute   : C++ attributes ([[nodiscard]], [[noreturn]], etc.)
  */
 
 const CppHighlight = (function () {
@@ -59,6 +60,26 @@ const CppHighlight = (function () {
     const n = code.length
 
     while (i < n) {
+      // C++ attributes [[...]] with nesting support
+      if (code[i] === '[' && code[i + 1] === '[') {
+        const start = i
+        i += 2
+        let depth = 1
+        while (i < n && depth > 0) {
+          if (code[i] === '[' && code[i + 1] === '[') {
+            depth++
+            i += 2
+          } else if (code[i] === ']' && code[i + 1] === ']') {
+            depth--
+            i += 2
+          } else {
+            i++
+          }
+        }
+        result.push(span('attribute', code.slice(start, i)))
+        continue
+      }
+
       // Line comment
       if (code[i] === '/' && code[i + 1] === '/') {
         let end = i + 2


### PR DESCRIPTION
This PR enhances C++ syntax highlighting in the documentation by adding support for C++ attributes (e.g., `[[nodiscard]]`, `[[noreturn]]`). 

Changes include:

- Updates to `cpp-highlight.css` to style attributes in gray.
- Enhancements to `cpp-highlight.js` for parsing C++ attributes with nesting support.
- Minor adjustments to existing syntax highlighting rules.