### PR TITLE
Fix ui-release to run on workflow_dispatch and auto-detect boostlook branch

### DIFF
--- a/.github/workflows/ui-release.yml
+++ b/.github/workflows/ui-release.yml
@@ -16,9 +16,9 @@ on:
   workflow_dispatch:
     inputs:
       boostlook_branch:
-        description: 'Branch to use for boostlook.css'
-        required: true
-        default: 'master'
+        description: 'Branch to use for boostlook.css (leave empty to auto-detect from branch)'
+        required: false
+        default: ''
 
 concurrency:
   group: ${{format('ui-release-{0}:{1}', github.repository, github.ref)}}
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') && github.event_name == 'push' }}
+    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
     permissions:
       contents: write
 
@@ -46,7 +46,7 @@ jobs:
     - name: Build
       working-directory: antora-ui
       run: |
-        export BOOSTLOOK_BRANCH="${{ github.event.inputs.boostlook_branch || 'master' }}"
+        export BOOSTLOOK_BRANCH="${{ github.event.inputs.boostlook_branch || (startsWith(github.ref, 'refs/heads/develop') && 'develop') || 'master' }}"
         npm ci
         gulp bundle
 


### PR DESCRIPTION
  ## Problem
  When `boostlook/develop` merges a PR and triggers `website-v2-docs` via `workflow_dispatch`, the
  ui-bundle does not rebuild with the updated CSS because:

  1. **Line 30**: The build job only runs on `push` events, skipping `workflow_dispatch` entirely
  2. **Line 49**: `BOOSTLOOK_BRANCH` defaults to `master` even when triggered on the `develop` branch
  3. **Lines 18-21**: The input has `required: true` with `default: 'master'`, preventing auto-detection

  ## Solution
  - Allow `workflow_dispatch` events in the job condition
  - Auto-detect `develop` branch when no input is provided
  - Make the input optional with an empty default to enable auto-detection

  ## Testing
  Tested on my fork by:
  1. Running workflow_dispatch on `develop` branch with empty input
  2. Verified `BOOSTLOOK_BRANCH=develop` was used
  3. Confirmed `ui-bundle.zip` contained latest `boostlook.css` from `develop`

https://github.com/julioest/website-v2-docs/releases/download/ui-develop/ui-bundle.zip

Refers to issue: https://github.com/boostorg/boostlook/issues/142