### PR TITLE
Enable mermaid diagram rendering for library and site docs

### DIFF
--- a/antora-ui/src/css/doc.css
+++ b/antora-ui/src/css/doc.css
@@ -449,6 +449,10 @@
   vertical-align: middle;
 }
 
+.doc .imageblock .mermaid.content {
+  width: 100%;
+}
+
 .doc .image:not(.left):not(.right) > img {
   margin-top: -0.2em;
 }

--- a/libs.playbook.yml
+++ b/libs.playbook.yml
@@ -60,6 +60,11 @@ antora:
           tag: 'develop'
           variable: 'BOOST_SRC_DIR'
           system-env: 'BOOST_SRC_DIR'
+    - require: '@sntke/antora-mermaid-extension'
+      mermaid_library_url: https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs
+      script_stem: header-scripts
+      mermaid_initialize_options:
+        start_on_load: true
 
 asciidoc:
   attributes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "site-docs",
+  "name": "website-v2-docs",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -10,7 +10,8 @@
         "@cppalliance/antora-cpp-reference-extension": "^0.1.0",
         "@cppalliance/antora-cpp-tagfiles-extension": "^0.1.0",
         "@cppalliance/antora-playbook-macros-extension": "^0.0.2",
-        "@cppalliance/asciidoctor-boost-links": "^0.0.2"
+        "@cppalliance/asciidoctor-boost-links": "^0.0.2",
+        "@sntke/antora-mermaid-extension": "^0.0.8"
       }
     },
     "node_modules/@antora/expand-path-helper": {
@@ -122,6 +123,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@sntke/antora-mermaid-extension": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@sntke/antora-mermaid-extension/-/antora-mermaid-extension-0.0.8.tgz",
+      "integrity": "sha512-tTGNECQJcJaz2m/W2izgVNLO78LBq1OyNxIpTYU/IslkRjN62ghZfK25sZTfpvJQjKeNTOnx+SmFcCpq/Sn3FQ==",
+      "license": "MIT"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "dependencies": {
+    "@antora/lunr-extension": "^1.0.0-alpha.12",
+    "@asciidoctor/tabs": "^1.0.0-beta.6",
     "@cppalliance/antora-cpp-reference-extension": "^0.1.0",
     "@cppalliance/antora-cpp-tagfiles-extension": "^0.1.0",
     "@cppalliance/antora-playbook-macros-extension": "^0.0.2",
     "@cppalliance/asciidoctor-boost-links": "^0.0.2",
-    "@antora/lunr-extension": "^1.0.0-alpha.12",
-    "@asciidoctor/tabs": "^1.0.0-beta.6"
+    "@sntke/antora-mermaid-extension": "^0.0.8"
   }
 }

--- a/site.playbook.yml
+++ b/site.playbook.yml
@@ -45,6 +45,11 @@ antora:
       cpp-tagfiles:
         using-namespaces:
           - 'boost::'
+    - require: '@sntke/antora-mermaid-extension'
+      mermaid_library_url: https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs
+      script_stem: header-scripts
+      mermaid_initialize_options:
+        start_on_load: true
 
 asciidoc:
   attributes:


### PR DESCRIPTION
- Add @sntke/antora-mermaid-extension to both libs.playbook.yml and site.playbook.yml to support mermaid diagrams
- Includes a CSS fix to ensure diagrams render at full content width

### Preview
<img width="2720" height="1490" alt="image" src="https://github.com/user-attachments/assets/0c1db448-c9e0-4b94-8a14-3658a9627347" />

fixes #592 