### PR TITLE
Remove Boost Graph library from playbook

### DIFF
--- a/libs.playbook.yml
+++ b/libs.playbook.yml
@@ -82,8 +82,6 @@ content:
       start_path: doc
     - url: https://github.com/boostorg/url
       start_path: doc
-    - url: https://github.com/boostorg/graph
-      start_path: doc
       
 ui:
   bundle:


### PR DESCRIPTION
Removed the Boost Graph library documentation reference.