### PR TITLE
Add @antora/collector-extension to the playbooks

### DIFF
--- a/libs.playbook.yml
+++ b/libs.playbook.yml
@@ -49,6 +49,7 @@ antora:
         page-boost-branch: develop
         page-boost-ui-branch: develop
         page-commit-id: '000000'
+    - require: '@antora/collector-extension'
     - require: '@cppalliance/antora-cpp-tagfiles-extension'
       cpp-tagfiles:
         using-namespaces:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@antora/collector-extension": "^1.0.3",
         "@antora/lunr-extension": "^1.0.0-alpha.12",
         "@asciidoctor/tabs": "^1.0.0-beta.6",
         "@cppalliance/antora-cpp-reference-extension": "^0.1.0",
@@ -13,6 +14,22 @@
         "@cppalliance/antora-playbook-macros-extension": "^0.0.2",
         "@cppalliance/asciidoctor-boost-links": "^0.0.2",
         "@sntke/antora-mermaid-extension": "^0.0.8"
+      }
+    },
+    "node_modules/@antora/collector-extension": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@antora/collector-extension/-/collector-extension-1.0.3.tgz",
+      "integrity": "sha512-ji/6AAL2BL1CNogYhiCy4IErkGvAAmQtJZW4UwVlgwIv4LRC9xTeJJpstC4u5nMkvAHAKxSpja4bNEjMotklAw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@antora/expand-path-helper": "~3.0",
+        "@antora/run-command-helper": "~1.0",
+        "cache-directory": "~2.0",
+        "fast-glob": "~3.3",
+        "js-yaml": "~4.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/@antora/expand-path-helper": {
@@ -37,6 +54,15 @@
         "lunr": "~2.3",
         "lunr-languages": "~1.10"
       },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@antora/run-command-helper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@antora/run-command-helper/-/run-command-helper-1.0.3.tgz",
+      "integrity": "sha512-srrGuqScOL/4BJ51uRJl/aPEme4sQ1R2OmuXizhXQVJBJbh9rsYsi4ys6W9Q/J/UDEClH2c2L0Y0TfJ331/8Lg==",
+      "license": "MPL-2.0",
       "engines": {
         "node": ">=16.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
+    "@antora/collector-extension": "^1.0.3",
     "@antora/lunr-extension": "^1.0.0-alpha.12",
     "@asciidoctor/tabs": "^1.0.0-beta.6",
     "@cppalliance/antora-cpp-reference-extension": "^0.1.0",

--- a/site.playbook.yml
+++ b/site.playbook.yml
@@ -41,6 +41,7 @@ antora:
         page-boost-branch: develop
         page-boost-ui-branch: develop
         page-commit-id: '000000'
+    - require: '@antora/collector-extension'
     - require: '@cppalliance/antora-cpp-tagfiles-extension'
       cpp-tagfiles:
         using-namespaces:


### PR DESCRIPTION
Registers the official Antora Collector extension so libraries can import files that live outside their doc/ content root (compiled example sources, tested snippet files) into the content catalog via an ext.collector scan declared in their own antora.yml.

Libraries that do not declare collector config are unaffected; the extension is a no-op for them. First consumer is Boost.Capy, whose documentation code blocks are included from sources compiled and run by its test suite.