### PR TITLE
Delist "Portability Hints using Borland C++ Compilers" Page

### DIFF
--- a/contributor-guide/modules/ROOT/nav.adoc
+++ b/contributor-guide/modules/ROOT/nav.adoc
@@ -23,7 +23,6 @@ Official repository: https://github.com/boostorg/website-v2-docs
 ** xref:design-guide/backwards-compatibility.adoc[]
 ** xref:design-guide/separate-compilation.adoc[]
 ** xref:design-guide/dependencies.adoc[]
-** xref:design-guide/borland.adoc[]
 
 * Development
 ** xref:version-control.adoc[]


### PR DESCRIPTION
The compilers listed on this page are so old that there's no point in supporting them, and this may give some kind of false impression they need to be tested for. For example C++Builder 6 was released in February of 2002.