### PR TITLE
Current Schedule table of reviews cleaned up

### DIFF
--- a/formal-reviews/modules/ROOT/pages/review-results.adoc
+++ b/formal-reviews/modules/ROOT/pages/review-results.adoc
@@ -20,12 +20,12 @@ Note:: The review results include recent completed reviews - where the library m
 [[currentschedule]]
 == Current Schedule
 
-[cols="1,1,1,1,2,2",stripes=even,options="header",frame=none]
+[cols="1,1,1,1,1,2",stripes=even,options="header",frame=none]
 |===
-| *Submission* | *Submitter* | *Links* | *Review Manager* | *Review Dates* | *Result*
-| Capy and Corosio | Vinnie Falco | https://github.com/cppalliance/capy[Capy Repo] https://develop.capy.cpp.al/capy/index.html[Capy Docs] https://github.com/cppalliance/corosio[Corosio Repo] https://develop.corosio.cpp.al/corosio/index.html[Corosio Docs] | Jeff Garland | June 23 - July 7, 2026 | TBD
-| https://github.com/cppalliance/int128[Int128] | Matt Borland | https://develop.int128.cpp.al/overview.html[Docs] https://github.com/cppalliance/int128[Lib] | Arnaud Becheler | July 22, 2026 - August 2, 2026 | TBD
-| https://github.com/correaa/boost-multi[Multi] Mini-Review | Alfredo Correa | https://github.com/correaa/boost-multi[Lib]  https://correaa.github.io/boost-multi/multi/intro.html[Docs] | Matt Borland | August 6, 2026 - August 11, 2026 | TBD 
+| *Submission* | *Submitter* | *Library*  | *Documentation* | *Review Manager* | *Review Dates*
+| Capy and Corosio | Vinnie Falco | https://github.com/cppalliance/capy[Capy Repo], https://github.com/cppalliance/corosio[Corosio Repo] | https://develop.capy.cpp.al/capy/index.html[Capy Docs], https://develop.corosio.cpp.al/corosio/index.html[Corosio Docs] | Jeff Garland | June 23 - July 7, 2026
+| Int128 | Matt Borland | https://github.com/cppalliance/int128[Int128 Repo] | https://develop.int128.cpp.al/overview.html[Int128 Docs] | Arnaud Becheler | July 22, 2026 - August 2, 2026
+| Multi Mini-Review | Alfredo Correa | https://github.com/correaa/boost-multi[Multi Repo]  | https://correaa.github.io/boost-multi/multi/intro.html[Multi Docs] | Matt Borland | August 6, 2026 - August 11, 2026
 |===
 
 === Review Managers


### PR DESCRIPTION
@mborland Cleaned up the Current Review Schedule table - removed the Result, tweaked the column sizes, divided Lib and Docs column into two columns. Looks neater to me but feedback welcome!